### PR TITLE
Fix Content-Type headers of /ton-proof/checkProof

### DIFF
--- a/src/TonProofDemoApi.ts
+++ b/src/TonProofDemoApi.ts
@@ -60,6 +60,9 @@ class TonProofDemoApiService {
 			const response = await (
 				await fetch(`${this.host}/ton-proof/checkProof`, {
 					method: 'POST',
+					headers: {
+						'Content-Type': 'application/json',
+					},
 					body: JSON.stringify(reqBody),
 				})
 			).json();


### PR DESCRIPTION
Post /ton-proof/checkProof is post as plain text instead of application/json

Luckily echo can handle that.

But unlucky, we are using gin that doesn't handle this automatically.

This PR fixes it to post as application/json content type.